### PR TITLE
Support new style django middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - "2.7"
-install: "pip install -r requirements.txt --use-mirrors"
+install: "pip install -r requirements.txt"
 script:
   - nosetests --with-coverage --cover-package=djstopie
 after_success:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 # Dev
 
 * Add support for Django 1.11
-* Drop support for Django 1.7 
+* Drop support for Django 1.7, 1.8, 1.9, 1.10
 
 # 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # [Changelog](https://github.com/yola/djtopie/releases)
 
+# Dev
+
+* Add support for Django 1.11
+* Drop support for Django 1.7 
+
 # 1.0.0
 
 * Drops support for Python 2.6

--- a/djstopie/middleware.py
+++ b/djstopie/middleware.py
@@ -3,8 +3,13 @@ from django.shortcuts import redirect
 from django.utils.module_loading import import_string
 from ua_parser import user_agent_parser
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 
-class UnsupportedBrowsersMiddleware:
+
+class UnsupportedBrowsersMiddleware(MiddlewareMixin):
     """Redirects unsupported IE browsers to error page."""
 
     def process_response(self, request, response):

--- a/djstopie/middleware.py
+++ b/djstopie/middleware.py
@@ -3,14 +3,17 @@ from django.shortcuts import redirect
 from django.utils.module_loading import import_string
 from ua_parser import user_agent_parser
 
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = object
 
-
-class UnsupportedBrowsersMiddleware(MiddlewareMixin):
+class UnsupportedBrowsersMiddleware(object):
     """Redirects unsupported IE browsers to error page."""
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+        super(UnsupportedBrowsersMiddleware, self).__init__()
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response = self.process_response(request, response)
+        return response
 
     def process_response(self, request, response):
         requested_url = request.path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django >= 1.8.0
+django==1.11.3
 ua-parser==0.3.5
 
 coveralls==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django >= 1.7.0
+django >= 1.8.0
 ua-parser==0.3.5
 
 coveralls==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=['djstopie'],
     test_suite='nose.collector',
     install_requires=[
-        'django >= 1.7.0',
+        'django >= 1.11.0',
         'ua-parser==0.3.5'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=['djstopie'],
     test_suite='nose.collector',
     install_requires=[
-        'django >= 1.11.0',
+        'django >= 1.11.0, < 1.12',
         'ua-parser==0.3.5'
     ]
 )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,3 +1,1 @@
-from django.conf.urls import patterns
-
-urlpatterns = patterns('')
+urlpatterns = ()


### PR DESCRIPTION
These changes are needed as part of upgraded yolacom and sitebuilderui to Django 1.11.

* Drops support for Django 1.7 (reached end of life in December 2015).
* Adds support for Django 1.11 and the new style middleware class

I think the version bump will be to 2.0.0