### PR TITLE
bump version for changes in supported django versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [Changelog](https://github.com/yola/djtopie/releases)
 
-# Dev
+# 2.0.0
 
 * Add support for Django 1.11
 * Drop support for Django 1.7, 1.8, 1.9, 1.10

--- a/djstopie/__init__.py
+++ b/djstopie/__init__.py
@@ -1,4 +1,4 @@
 """Redirect misbehaved versions of IE to an error page."""
 
-__version__ = '1.0.0'
+__version__ = '2.0.0'
 __url__ = 'https://github.com/yola/djstopie'


### PR DESCRIPTION
djstopie 2.0.0

Adds support for Django 1.11
Drops support for Django 1.7, 1.8, 1.9, 1.10

